### PR TITLE
Fix code formatting

### DIFF
--- a/src/decide.cpp
+++ b/src/decide.cpp
@@ -148,14 +148,12 @@ void Decide::Calc_CMV() {
   Decide::CMV[14] = Lic14();
 }
 
-
 /**
- * @brief There exists at least one set of two consecutive data points that are a distance greater than
-   the length, LENGTH1, apart. 
-   (0 ≤ LENGTH1)
+ * @brief There exists at least one set of two consecutive data points that are
+ a distance greater than the length, LENGTH1, apart. (0 ≤ LENGTH1)
 
- * @return true 
- * @return false 
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic0() {
@@ -213,17 +211,16 @@ bool Decide::Lic1() {
   return false;
 }
 
-
 /**
- * @brief There exists at least one set of three consecutive data points which form an angle such that:
-          angle < (PI−EPSILON) or angle > (PI+EPSILON)
-          The second of the three consecutive points is always the vertex of the angle. If either the first
-          point or the last point (or both) coincides with the vertex, the angle is undefined and the LIC
-          is not satisfied by those three points.
-          (0 ≤ EPSILON < PI)
- * 
- * @return true 
- * @return false 
+ * @brief There exists at least one set of three consecutive data points which
+ form an angle such that: angle < (PI−EPSILON) or angle > (PI+EPSILON) The
+ second of the three consecutive points is always the vertex of the angle. If
+ either the first point or the last point (or both) coincides with the vertex,
+ the angle is undefined and the LIC is not satisfied by those three points. (0 ≤
+ EPSILON < PI)
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic2() {
@@ -257,14 +254,12 @@ bool Decide::Lic2() {
   return false;
 }
 
-
 /**
- * @brief There exists at least one set of three consecutive data points that are the vertices of a triangle
-          with area greater than AREA1.
-          (0 ≤ AREA1)
+ * @brief There exists at least one set of three consecutive data points that
+ are the vertices of a triangle with area greater than AREA1. (0 ≤ AREA1)
 
- * @return true 
- * @return false 
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic3() {
@@ -292,22 +287,23 @@ bool Decide::Lic3() {
 }
 
 /**
- * @brief There exists at least one set of Q_PTS consecutive data points that lie in more than QUADS
-          quadrants. Where there is ambiguity as to which quadrant contains a given point, priority
-          of decision will be by quadrant number, i.e., I, II, III, IV. For example, the data point (0,0)
-          is in quadrant I, the point (-l,0) is in quadrant II, the point (0,-l) is in quadrant III, the point
-          (0,1) is in quadrant I and the point (1,0) is in quadrant I.
-          (2 ≤ Q PTS ≤ NUMPOINTS), (1 ≤ QUADS ≤ 3)
+ * @brief There exists at least one set of Q_PTS consecutive data points that
+ lie in more than QUADS quadrants. Where there is ambiguity as to which quadrant
+ contains a given point, priority of decision will be by quadrant number, i.e.,
+ I, II, III, IV. For example, the data point (0,0) is in quadrant I, the point
+ (-l,0) is in quadrant II, the point (0,-l) is in quadrant III, the point (0,1)
+ is in quadrant I and the point (1,0) is in quadrant I. (2 ≤ Q PTS ≤ NUMPOINTS),
+ (1 ≤ QUADS ≤ 3)
 
- * 
- * @return true 
- * @return false 
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic4() {
   if (NUMPOINTS < PARAMETERS.Q_PTS)
     return false;
-    
+
   for (int i = 0; i < NUMPOINTS - PARAMETERS.Q_PTS + 1; i++) {
     bool quadrants[4];
     for (int k = 0; k < 4; k++) {
@@ -345,13 +341,12 @@ bool Decide::Lic4() {
   return false;
 }
 
-
 /**
- * @brief There exists at least one set of two consecutive data points, (X[i],Y[i]) and (X[j],Y[j]), such
-          that X[j] - X[i] < 0. (where i = j-1)
- * 
- * @return true 
- * @return false 
+ * @brief There exists at least one set of two consecutive data points,
+ (X[i],Y[i]) and (X[j],Y[j]), such that X[j] - X[i] < 0. (where i = j-1)
+ *
+ * @return true
+ * @return false
  */
 bool Decide::Lic5() {
   // Iterate through consecutive pairs of data points
@@ -420,14 +415,14 @@ bool Decide::Lic6() {
 }
 
 /**
- * @brief There exists at least one set of two data points separated by exactly K PTS consecutive 
- * intervening points that are a distance greater than the length, LENGTH1, apart. The condition
-   is not met when NUMPOINTS < 3.
-   1 ≤ K PTS ≤ (NUMPOINTS−2)
+ * @brief There exists at least one set of two data points separated by exactly
+ K PTS consecutive
+ * intervening points that are a distance greater than the length, LENGTH1,
+ apart. The condition is not met when NUMPOINTS < 3. 1 ≤ K PTS ≤ (NUMPOINTS−2)
 
- * 
- * @return true 
- * @return false 
+ *
+ * @return true
+ * @return false
  */
 bool Decide::Lic7() {
   // create references
@@ -456,15 +451,14 @@ bool Decide::Lic7() {
 }
 
 /**
- * @brief There exists at least one set of three data points separated by exactly A PTS and B PTS
-          consecutive intervening points, respectively, that cannot be contained within or on a circle of
-          radius RADIUS1. The condition is not met when NUMPOINTS < 5.
-          1 ≤ A PTS, 1 ≤ B PTS
-          A PTS+B PTS ≤ (NUMPOINTS−3)
+ * @brief There exists at least one set of three data points separated by
+ exactly A PTS and B PTS consecutive intervening points, respectively, that
+ cannot be contained within or on a circle of radius RADIUS1. The condition is
+ not met when NUMPOINTS < 5. 1 ≤ A PTS, 1 ≤ B PTS A PTS+B PTS ≤ (NUMPOINTS−3)
 
- * 
- * @return true 
- * @return false 
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic8() {
@@ -508,17 +502,16 @@ bool Decide::Lic8() {
 }
 
 /**
- * @brief There exists at least one set of three data points separated by exactly C PTS and D PTS
-          consecutive intervening points, respectively, that form an angle such that:
-          angle < (PI−EPSILON) or angle > (PI+EPSILON)
-          The second point of the set of three points is always the vertex of the angle. If either the first
-          point or the last point (or both) coincide with the vertex, the angle is undefined and the LIC
-          is not satisfied by those three points. When NUMPOINTS < 5, the condition is not met.
-          1 ≤ C PTS, 1 ≤ D PTS
-          C PTS+D PTS ≤ NUMPOINTS−3
- * 
- * @return true 
- * @return false 
+ * @brief There exists at least one set of three data points separated by
+ exactly C PTS and D PTS consecutive intervening points, respectively, that form
+ an angle such that: angle < (PI−EPSILON) or angle > (PI+EPSILON) The second
+ point of the set of three points is always the vertex of the angle. If either
+ the first point or the last point (or both) coincide with the vertex, the angle
+ is undefined and the LIC is not satisfied by those three points. When NUMPOINTS
+ < 5, the condition is not met. 1 ≤ C PTS, 1 ≤ D PTS C PTS+D PTS ≤ NUMPOINTS−3
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic9() {
@@ -547,19 +540,19 @@ bool Decide::Lic9() {
 }
 
 /**
- * @brief There exists at least one set of three data points separated by exactly E_PTS and F_PTS 
- * consecutive intervening points, respectively, that are the vertices of a triangle with area greater
-   than AREA1. The condition is not met when NUMPOINTS < 5.
-   1 ≤ E PTS, 1 ≤ F PTS
-   E_PTS + F_PTS ≤ NUMPOINTS−3
- * 
- * @return true 
- * @return false 
+ * @brief There exists at least one set of three data points separated by
+ exactly E_PTS and F_PTS
+ * consecutive intervening points, respectively, that are the vertices of a
+ triangle with area greater than AREA1. The condition is not met when NUMPOINTS
+ < 5. 1 ≤ E PTS, 1 ≤ F PTS E_PTS + F_PTS ≤ NUMPOINTS−3
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic10() {
   if (NUMPOINTS < 5) {
-    return  false;
+    return false;
   }
 
   for (int i = 0; i < NUMPOINTS; ++i) {
@@ -573,7 +566,8 @@ bool Decide::Lic10() {
     COORDINATE c3 = COORDINATES[i + PARAMETERS.E_PTS + PARAMETERS.F_PTS + 2];
 
     // Calculate the area of the triangle formed by points (i, j, k)
-    double area = 0.5 * fabs(c1.x * (c2.y - c3.y) + c2.x * (c3.y - c1.y) + c3.x * (c1.y - c2.y));
+    double area = 0.5 * fabs(c1.x * (c2.y - c3.y) + c2.x * (c3.y - c1.y) +
+                             c3.x * (c1.y - c2.y));
     if (DOUBLECOMPARE(area, PARAMETERS.AREA1) == GT) {
       // Set CMV[9] to true if condition is met
       return true;
@@ -607,16 +601,16 @@ bool Decide::Lic11() {
 }
 
 /**
- * @brief There exists at least one set of two data points, separated by exactly K PTS consecutive
-          intervening points, which are a distance greater than the length, LENGTH1, apart. In addition, 
-          there exists at least one set of two data points (which can be the same or different from
-          the two data points just mentioned), separated by exactly K PTS consecutive intervening
-          points, that are a distance less than the length, LENGTH2, apart. Both parts must be true
-          for the LIC to be true. The condition is not met when NUMPOINTS < 3.
-          0 ≤ LENGTH2
- * 
- * @return true 
- * @return false 
+ * @brief There exists at least one set of two data points, separated by exactly
+ K PTS consecutive intervening points, which are a distance greater than the
+ length, LENGTH1, apart. In addition, there exists at least one set of two data
+ points (which can be the same or different from the two data points just
+ mentioned), separated by exactly K PTS consecutive intervening points, that are
+ a distance less than the length, LENGTH2, apart. Both parts must be true for
+ the LIC to be true. The condition is not met when NUMPOINTS < 3. 0 ≤ LENGTH2
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic12() {
@@ -664,20 +658,19 @@ bool Decide::Lic12() {
   }
 }
 
-
 /**
- * @brief There exists at least one set of three data points, separated by exactly A PTS and B PTS
-consecutive intervening points, respectively, that cannot be contained within or on a circle of
-radius RADIUS1. In addition, there exists at least one set of three data points (which can be
-the same or different from the three data points just mentioned) separated by exactly A PTS
-and B PTS consecutive intervening points, respectively, that can be contained in or on a
-circle of radius RADIUS2. Both parts must be true for the LIC to be true. The condition is
-not met when NUMPOINTS < 5.
-0 ≤ RADIUS2
+ * @brief There exists at least one set of three data points, separated by
+exactly A PTS and B PTS consecutive intervening points, respectively, that
+cannot be contained within or on a circle of radius RADIUS1. In addition, there
+exists at least one set of three data points (which can be the same or different
+from the three data points just mentioned) separated by exactly A PTS and B PTS
+consecutive intervening points, respectively, that can be contained in or on a
+circle of radius RADIUS2. Both parts must be true for the LIC to be true. The
+condition is not met when NUMPOINTS < 5. 0 ≤ RADIUS2
 
- * 
- * @return true 
- * @return false 
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic13() {
@@ -729,19 +722,19 @@ bool Decide::Lic13() {
   return found_smaller_triangle && found_larger_triangle;
 }
 
-
 /**
- * @brief There exists at least one set of three data points, separated by exactly E_PTS and F_PTS 
- * consecutive intervening points, respectively, that are the vertices of a triangle with area greater
-   than AREA1. In addition, there exist three data points (which can be the same or different
-   from the three data points just mentioned) separated by exactly E PTS and F PTS consecutive intervening points,
+ * @brief There exists at least one set of three data points, separated by
+ exactly E_PTS and F_PTS
+ * consecutive intervening points, respectively, that are the vertices of a
+ triangle with area greater than AREA1. In addition, there exist three data
+ points (which can be the same or different from the three data points just
+ mentioned) separated by exactly E PTS and F PTS consecutive intervening points,
    respectively, that are the vertices of a triangle with area less than
-   AREA2. Both parts must be true for the LIC to be true. The condition is not met when
-   NUMPOINTS < 5.
-   0 ≤ AREA2
- * 
- * @return true 
- * @return false 
+   AREA2. Both parts must be true for the LIC to be true. The condition is not
+ met when NUMPOINTS < 5. 0 ≤ AREA2
+ *
+ * @return true
+ * @return false
  */
 
 bool Decide::Lic14() {
@@ -759,7 +752,7 @@ bool Decide::Lic14() {
     a.push_back(COORDINATES[i + PARAMETERS.E_PTS + 1]);
     a.push_back(COORDINATES[i + PARAMETERS.E_PTS + PARAMETERS.F_PTS + 2]);
     double area = fabs(a[0].x * a[1].y + a[1].x * a[2].y + a[2].x * a[0].y -
-                  a[0].x * a[2].y - a[1].x * a[0].y - a[2].x * a[1].y) /
+                       a[0].x * a[2].y - a[1].x * a[0].y - a[2].x * a[1].y) /
                   2;
 
     // check for area condition 1
@@ -777,8 +770,6 @@ bool Decide::Lic14() {
   }
   return false;
 }
-
-
 
 void Decide::Calc_PUM() {
   for (int x = 0; x < 15; ++x) {
@@ -804,7 +795,6 @@ void Decide::Calc_PUM() {
     }
   }
 }
-
 
 void Decide::Calc_FUV() {
   bool a;

--- a/src/decide.h
+++ b/src/decide.h
@@ -1,9 +1,9 @@
 #ifndef DECIDE_H
 #define DECIDE_H
 
+#include "gtest/gtest.h"
 #include <array>
 #include <vector>
-#include "gtest/gtest.h"
 
 const double PI = 3.1415926535;
 
@@ -18,25 +18,25 @@ struct COORDINATE {
 };
 
 struct PARAMETERS_T {
-  double LENGTH1;  // Length in LICs 0, 7, 12
-  double RADIUS1;  // Radius in LICs 1, 8, 13
-  double EPSILON;  // Deviation from PI in LICs 2, 9
-  double AREA1;    // Area in LICs 1, 8, 13
-  int Q_PTS;       // No. of consecutive points in LIC 4
-  int QUADS;       // No. of quadrants in LIC 4
-  double DIST;     // Distance in LIC 6
-  int N_PTS;       // No. of consecutive pts. in LIC 6
-  int K_PTS;       // No. of int. pts. in LICs 7, 12
-  int A_PTS;       // No. of int. pts. in LICs 8, 13
-  int B_PTS;       // No. of int. pts. in LICs 8, 13
-  int C_PTS;       // No. of int. pts. in LIC 9
-  int D_PTS;       // No. of int. pts. in LIC 9
-  int E_PTS;       // No. of int. pts. in LICS 10, 14
-  int F_PTS;       // No. of int. pts. in LICS 10, 14
-  int G_PTS;       // No. of int. pts. in LIC 11
-  double LENGTH2;  // Maximum length in LIC 12
-  double RADIUS2;  // Maximum radius in LIC 13
-  double AREA2;    // Maximum area in LIC 14
+  double LENGTH1; // Length in LICs 0, 7, 12
+  double RADIUS1; // Radius in LICs 1, 8, 13
+  double EPSILON; // Deviation from PI in LICs 2, 9
+  double AREA1;   // Area in LICs 1, 8, 13
+  int Q_PTS;      // No. of consecutive points in LIC 4
+  int QUADS;      // No. of quadrants in LIC 4
+  double DIST;    // Distance in LIC 6
+  int N_PTS;      // No. of consecutive pts. in LIC 6
+  int K_PTS;      // No. of int. pts. in LICs 7, 12
+  int A_PTS;      // No. of int. pts. in LICs 8, 13
+  int B_PTS;      // No. of int. pts. in LICs 8, 13
+  int C_PTS;      // No. of int. pts. in LIC 9
+  int D_PTS;      // No. of int. pts. in LIC 9
+  int E_PTS;      // No. of int. pts. in LICS 10, 14
+  int F_PTS;      // No. of int. pts. in LICS 10, 14
+  int G_PTS;      // No. of int. pts. in LIC 11
+  double LENGTH2; // Maximum length in LIC 12
+  double RADIUS2; // Maximum radius in LIC 13
+  double AREA2;   // Maximum area in LIC 14
 };
 
 class Decide {
@@ -96,7 +96,7 @@ class Decide {
   FRIEND_TEST(CMV, LIC14_NEGATIVE);
   // DUMMY TEST
   FRIEND_TEST(CMV, LIC11);
-  
+
   FRIEND_TEST(LAUNCH, LAUNCH_POSITIVE);
   FRIEND_TEST(LAUNCH, LAUNCH_POSITIVE2);
   FRIEND_TEST(LAUNCH, LAUNCH_POSITIVE3);
@@ -105,32 +105,32 @@ class Decide {
 
 private:
   // Inputs
-  const int NUMPOINTS;  // Number of planar data points.
+  const int NUMPOINTS; // Number of planar data points.
   const std::vector<COORDINATE>
-      COORDINATES;  // Array containing the coordinates of data points.
-  const PARAMETERS_T PARAMETERS;  // Struct holding the parameters for LICs.
+      COORDINATES; // Array containing the coordinates of data points.
+  const PARAMETERS_T PARAMETERS; // Struct holding the parameters for LICs.
   const std::array<std::array<CONNECTORS, 15>, 15>
-      LCM;  // Logical Connector Matrix. IMPORTANT! LCM[y][x] <-- y first then
-            // x.
-  const std::array<bool, 15> PUV;  // Preliminary unlocking vector.
+      LCM; // Logical Connector Matrix. IMPORTANT! LCM[y][x] <-- y first then
+           // x.
+  const std::array<bool, 15> PUV; // Preliminary unlocking vector.
 
   // Outputs
   bool LAUNCH;
-  std::array<bool, 15> CMV;  // Conditions Met Vector.
+  std::array<bool, 15> CMV; // Conditions Met Vector.
   std::array<std::array<bool, 15>, 15>
-      PUM;  // Preliminary Unlocking Matrix. IMPORTANT! PUM[y][x] <-- y first
-            // then x.
-  std::array<bool, 15> FUV;  // Final Unlocking Vector.
+      PUM; // Preliminary Unlocking Matrix. IMPORTANT! PUM[y][x] <-- y first
+           // then x.
+  std::array<bool, 15> FUV; // Final Unlocking Vector.
 
   // Methods
   // Method for comparing doubles.
   COMPTYPE DOUBLECOMPARE(double A, double B) const;
   // Method for calculating the angle formed by three points.
-  double COMPUTEANLGE(const COORDINATE& point1, const COORDINATE& point2,
-                      const COORDINATE& point3);
+  double COMPUTEANLGE(const COORDINATE &point1, const COORDINATE &point2,
+                      const COORDINATE &point3);
   // Method for validating the points forming an angle
-  bool VALIDATEANGLE(const COORDINATE& point1, const COORDINATE& point2,
-                     const COORDINATE& point3);
+  bool VALIDATEANGLE(const COORDINATE &point1, const COORDINATE &point2,
+                     const COORDINATE &point3);
 
   // Step 2.1 from specification.
   void Calc_CMV();
@@ -160,11 +160,11 @@ private:
   // 2.4 from specification.
   void Calc_LAUNCH();
 
- public:
-  Decide(int NUMPOINTS, const std::vector<COORDINATE>& POINTS,
-         const PARAMETERS_T& PARAMETERS,
-         const std::array<std::array<CONNECTORS, 15>, 15>& LCM,
-         const std::array<bool, 15>& PUV);
+public:
+  Decide(int NUMPOINTS, const std::vector<COORDINATE> &POINTS,
+         const PARAMETERS_T &PARAMETERS,
+         const std::array<std::array<CONNECTORS, 15>, 15> &LCM,
+         const std::array<bool, 15> &PUV);
 
   // Call functions for 2.1 - 2.4 and print answer to stdout.
   void decide();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
 #include "decide.h"
 #include <fstream>
+#include <iostream>
 
 int main(int argc, char *argv[]) {
   // dummy values for testing

--- a/test/CMVTest.cpp
+++ b/test/CMVTest.cpp
@@ -1,21 +1,25 @@
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
 #include "decide.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
-// Positive test case for LIC0(), 
-// check that it can find two consecutive points 
+// Positive test case for LIC0(),
+// check that it can find two consecutive points
 // that are a greater distance of LENGTH1 apart
 // Expected value TRUE
-TEST(CMV, LIC0_POSITIVE){
+TEST(CMV, LIC0_POSITIVE) {
   // Define input points and parameters
   std::vector<COORDINATE> points = {
-      {0, 0}, {3, 4}, {8, 10}, {12, 15}  // Ensure distance between consecutive points is greater than LENGTH1
+      {0, 0},
+      {3, 4},
+      {8, 10},
+      {12,
+       15} // Ensure distance between consecutive points is greater than LENGTH1
   };
 
   PARAMETERS_T parameters;
-  parameters.LENGTH1 = 5.0;  // LENGTH1 (assuming LENGTH1 is set to 5.0)
-                             // other parameter values
-  
+  parameters.LENGTH1 = 5.0; // LENGTH1 (assuming LENGTH1 is set to 5.0)
+                            // other parameter values
+
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
   std::array<bool, 15> puv;
 
@@ -29,42 +33,44 @@ TEST(CMV, LIC0_POSITIVE){
 // Negative test case for LIC0(),
 // if no two consecutive points are apart a greater distance
 // than LENGTH1, the LIC is not met
-// Expected value FALSE 
+// Expected value FALSE
 TEST(CMV, LIC0_NEGATIVE) {
   // Define input points and parameters
   std::vector<COORDINATE> points = {
-      {0, 0}, {1, 1}, {2, 2}, {3, 3}  // Ensure distance between consecutive points is not greater than LENGTH1
+      {0, 0}, {1, 1}, {2, 2}, {3, 3} // Ensure distance between consecutive
+                                     // points is not greater than LENGTH1
   };
 
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
   std::array<bool, 15> puv;
 
   PARAMETERS_T parameters;
-  parameters.LENGTH1 = 5.0; 
+  parameters.LENGTH1 = 5.0;
 
   // Create Decide object with the provided points and parameters
   Decide decide(points.size(), points, parameters, lcm, puv);
 
-  // Ensure the function returns false since distances are not greater than LENGTH1
+  // Ensure the function returns false since distances are not greater than
+  // LENGTH1
   EXPECT_FALSE(decide.Lic0());
 }
 
 // Positive test case LIC1(),
 // if three consecutive data points forms an area
 // check that at least one point is outside a circles radius of RADIUS1
-// this is done by calculating the area of the triangle, and then the circumcircle of the triangle
-// In this case, the radius of the circumcircle should be greater than the RADIUS1
-// Expected value TRUE
+// this is done by calculating the area of the triangle, and then the
+// circumcircle of the triangle In this case, the radius of the circumcircle
+// should be greater than the RADIUS1 Expected value TRUE
 TEST(CMV, LIC1_POSITIVE) {
   std::vector<COORDINATE> pointsP = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}};
-  
+
   PARAMETERS_T paramP;
   paramP.RADIUS1 = 0.5;
   std::array<std::array<CONNECTORS, 15>, 15> lcmP;
   std::array<bool, 15> puvP = {0};
 
   Decide decideP(pointsP.size(), pointsP, paramP, lcmP, puvP);
-  
+
   // Ensure the function returns true
   EXPECT_EQ(decideP.Lic1(), true);
 }
@@ -87,9 +93,9 @@ TEST(CMV, LIC1_NEGATIVE) {
 
 // Boundary test case for LIC1(),
 // Test the special case of a boundrary, when the radius of the circumcircle
-// is equal to the RADIUS1, meaning all points are either on or inside the RADIUS1 circle
-// This should result in the LIC condition not being met
-// Expected value FALSE
+// is equal to the RADIUS1, meaning all points are either on or inside the
+// RADIUS1 circle This should result in the LIC condition not being met Expected
+// value FALSE
 TEST(CMV, LIC1_BOUNDRARY) {
   std::vector<COORDINATE> pointsB = {{0, 0}, {3, 0}, {0, 4}};
   PARAMETERS_T paramB;
@@ -103,7 +109,7 @@ TEST(CMV, LIC1_BOUNDRARY) {
   EXPECT_EQ(decideB.Lic1(), false);
 }
 
-// Positive test for LIC2(), 
+// Positive test for LIC2(),
 // Test that it can calculate an angle formed by three consecutive points
 // where point two is the vertex, that is less than PI + EPSILON
 // Expected value TRUE
@@ -125,7 +131,7 @@ TEST(CMV, LIC2_POSITIVE) {
   EXPECT_EQ(decide.Lic2(), true);
 }
 
-// Negative tests for LIC2(), 
+// Negative tests for LIC2(),
 // can identify when there is a bad angle (two points are on eachother)
 // and reject it
 // expected value FALSE
@@ -147,7 +153,7 @@ TEST(CMV, LIC2_NEGATIVE_BAD_ANGLE) {
   EXPECT_EQ(decide.Lic2(), false);
 }
 
-// Positive test for LIC3(), 
+// Positive test for LIC3(),
 // Tests that it can identify a triangle from three consecutive points
 // that has a greater area than PARAMETERS.AREA1
 // Expected value TRUE
@@ -213,23 +219,22 @@ TEST(CMV, LIC3_BOUNDRARY) {
 }
 
 // Positive tests for LIC4(),
-// Test that it can correctly identify each consecutive point being in a quadrant
-// and check that the amount if different quadrants that the points cover
-// is more than QUADS
-// Expected value TRUE
+// Test that it can correctly identify each consecutive point being in a
+// quadrant and check that the amount if different quadrants that the points
+// cover is more than QUADS Expected value TRUE
 TEST(CMV, LIC4_POSITIVE) {
   // these points will result in 2 different quadrants being covered
   std::vector<COORDINATE> points2 = {{0, 0}, {-1, 1}, {-2, 2}};
 
   PARAMETERS_T parameters;
   parameters.Q_PTS = 3;
-  parameters.QUADS = 1; // we check that more than 1 quadrant is covered => 
+  parameters.QUADS = 1; // we check that more than 1 quadrant is covered =>
                         // 2 > 1 => CONDITION MET
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
   std::array<bool, 15> puv;
 
   Decide decide2(points2.size(), points2, parameters, lcm, puv);
-  
+
   EXPECT_EQ(decide2.Lic4(), true);
 }
 
@@ -259,7 +264,11 @@ TEST(CMV, LIC4_NEGATIVE) {
 TEST(CMV, LIC5_POSITIVE) {
   // Define input points and parameters
   std::vector<COORDINATE> points = {
-      {1, 1},{0, 0},{3, 3},{2, 2},   // Ensure X[j] - X[i] < 0 for at least one pair of consecutive points
+      {1, 1},
+      {0, 0},
+      {3, 3},
+      {2,
+       2}, // Ensure X[j] - X[i] < 0 for at least one pair of consecutive points
   };
 
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
@@ -269,7 +278,8 @@ TEST(CMV, LIC5_POSITIVE) {
 
   Decide decide(points.size(), points, parameters, lcm, puv);
 
-  // Ensure the function returns true since X[j] - X[i] < 0 for at least one pair of consecutive points
+  // Ensure the function returns true since X[j] - X[i] < 0 for at least one
+  // pair of consecutive points
   EXPECT_TRUE(decide.Lic5());
 }
 
@@ -280,7 +290,10 @@ TEST(CMV, LIC5_POSITIVE) {
 TEST(CMV, LIC5_NEGATIVE) {
 
   std::vector<COORDINATE> points = {
-      {0, 0}, {1, 1}, {2, 2}, {3, 3}  // Ensure X[j] - X[i] >= 0 for all pairs of consecutive points
+      {0, 0},
+      {1, 1},
+      {2, 2},
+      {3, 3} // Ensure X[j] - X[i] >= 0 for all pairs of consecutive points
   };
 
   PARAMETERS_T parameters;
@@ -289,7 +302,8 @@ TEST(CMV, LIC5_NEGATIVE) {
   // Create Decide object with the provided points
   Decide decide(points.size(), points, parameters, lcm, puv);
 
-  // Ensure the function returns false since X[j] - X[i] >= 0 for all pairs of consecutive points
+  // Ensure the function returns false since X[j] - X[i] >= 0 for all pairs of
+  // consecutive points
   EXPECT_FALSE(decide.Lic5());
 }
 
@@ -318,7 +332,7 @@ TEST(CMV, LIC6_NEGATIVE) {
   std::vector<COORDINATE> pointsN = {{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}};
   // distance=0
   // create parameters container
-  
+
   PARAMETERS_T paramN;
   paramN.DIST = 50;
   paramN.N_PTS = 3;
@@ -336,7 +350,7 @@ TEST(CMV, LIC6_NEGATIVE) {
 // Expected value FALSE
 TEST(CMV, LIC6_BOUNDRARY) {
   std::vector<COORDINATE> pointsB = {{0, 0}, {3, 0}, {0, 4}, {3, 4}, {3, 4}};
-  // 
+  //
   // create parameters container
   PARAMETERS_T paramB;
   paramB.DIST = 5;
@@ -419,8 +433,8 @@ TEST(CMV, LIC7_NEGATIVE_NUMPOINTS) {
 }
 
 // Positive test case for LIC8(),
-// Test whether the LIC8 will return true when three points can't be included in a circle
-// Expected value TRUE
+// Test whether the LIC8 will return true when three points can't be included in
+// a circle Expected value TRUE
 TEST(CMV, LIC8_POSITIVE) {
   // triangle {0,0},{0,100},{100,0} cant fit in circle with radius 1
   std::vector<COORDINATE> points = {{0, 0}, {0, 0}, {0, 0},  {0, 100},
@@ -443,8 +457,8 @@ TEST(CMV, LIC8_POSITIVE) {
 }
 
 // Negative test case for LIC8(),
-// Test whether the LIC8 will return false when three points can be included in a circle
-// Expected value FALSE
+// Test whether the LIC8 will return false when three points can be included in
+// a circle Expected value FALSE
 TEST(CMV, LIC8_NEGATIVE) {
   // triangle {0,0},{0,1},{1,0} cant fit in circle with radius 100
   std::vector<COORDINATE> points = {{0, 0}, {0, 0}, {0, 0}, {0, 1},
@@ -467,8 +481,8 @@ TEST(CMV, LIC8_NEGATIVE) {
 }
 
 // Boundrary test case for LIC8(),
-// Test whether the LIC8 will return false when three points can be exactly on the circle
-// Expected value FALSE
+// Test whether the LIC8 will return false when three points can be exactly on
+// the circle Expected value FALSE
 TEST(CMV, LIC8_BOUNDRARY) {
   // triangle {0,0},{0,1},{1,0} has a circumradius
   // of (1/2)*sqrt(2)
@@ -494,9 +508,9 @@ TEST(CMV, LIC8_BOUNDRARY) {
 // Tests that LIC9 can reject when points the angle is small
 // Expected value TRUE
 TEST(CMV, LIC9_POSITIVE) {
-  std::vector<COORDINATE> points = {{0,0}, {0,1}, {1,1}, {1,0}, {-1,1}};
-  //angle=PI/4<PI-2
-  // create parameters container
+  std::vector<COORDINATE> points = {{0, 0}, {0, 1}, {1, 1}, {1, 0}, {-1, 1}};
+  // angle=PI/4<PI-2
+  //  create parameters container
   PARAMETERS_T parameters;
   parameters.D_PTS = 1;
   parameters.C_PTS = 1;
@@ -511,12 +525,12 @@ TEST(CMV, LIC9_POSITIVE) {
 }
 
 // Negative test case for LIC9(),
-// Tests that LIC9 can reject when points the angle is large 
+// Tests that LIC9 can reject when points the angle is large
 // Expected value FALSE
 TEST(CMV, LIC9_NEGATIVE) {
-  std::vector<COORDINATE> points = { {0,0}, {0,1}, {1,1}, {1,0}, {2,1}};
-  //PI>angle=3PI/4>PI-2
-  // create parameters container
+  std::vector<COORDINATE> points = {{0, 0}, {0, 1}, {1, 1}, {1, 0}, {2, 1}};
+  // PI>angle=3PI/4>PI-2
+  //  create parameters container
   PARAMETERS_T parameters;
   parameters.D_PTS = 1;
   parameters.C_PTS = 1;
@@ -531,20 +545,71 @@ TEST(CMV, LIC9_NEGATIVE) {
 }
 
 // Positive test case for LIC10(),
-// Test case for Decide::Lic10() returning true when 
+// Test case for Decide::Lic10() returning true when
 // at least one triangle has area greater than AREA1
 // Expected value TRUE
 TEST(CMV, LIC10_POSITIVE) {
   // Define input points and parameters
   std::vector<COORDINATE> points = {
-      {0, 0}, {1, 0}, {0, 20}, {3, 1}, {20, 0}  // Ensure area of at least one triangle is greater than AREA1
+      {0, 0},
+      {1, 0},
+      {0, 20},
+      {3, 1},
+      {20, 0} // Ensure area of at least one triangle is greater than AREA1
   };
   // create parameters container
   PARAMETERS_T parameters = {
-      0,  // LENGTH1
+      0, // LENGTH1
+      0, // RADIUS1
+      0, // EPSILON
+      5, // AREA1: Set to a value that the area of at least one triangle formed
+         // by the input points will exceed
+      0, // Q_PTS
+      0, // QUADS
+      0, // DIST
+      0, // N_PTS
+      0, // K_PTS
+      0, // A_PTS
+      0, // B_PTS
+      0, // C_PTS
+      0, // D_PTS
+      1, // E_PTS
+      1, // F_PTS
+      0, // G_PTS
+      0, // LENGTH2
+      0, // RADIUS2
+      0  // AREA2
+  };
+  // these variables dont matter for this test
+  std::array<std::array<CONNECTORS, 15>, 15> lcm;
+  std::array<bool, 15> puv = {0};
+
+  Decide decide(points.size(), points, parameters, lcm, puv);
+
+  // Ensure the function returns true since the condition is met for at least
+  // one triangle
+  EXPECT_TRUE(decide.Lic10());
+}
+
+// Negative test case for LIC10(),
+// Test case for Decide::Lic10() returning true when all triangles have area
+// within threshold Expected value FALSE
+TEST(CMV, LIC10_NEGATIVE) {
+  // Define input points and parameters
+  std::vector<COORDINATE> points = {
+      {0, 0},
+      {1, 0},
+      {0, 1},
+      {1, 1},
+      {2, 2} // Ensure area of all triangles is within threshold
+  };
+  // create parameters container
+  PARAMETERS_T parameters = {
+      10, // LENGTH1
       0,  // RADIUS1
       0,  // EPSILON
-      5,  // AREA1: Set to a value that the area of at least one triangle formed by the input points will exceed
+      10, // AREA1: Set to a value that no triangle formed by the input points
+          // will exceed
       0,  // Q_PTS
       0,  // QUADS
       0,  // DIST
@@ -567,47 +632,8 @@ TEST(CMV, LIC10_POSITIVE) {
 
   Decide decide(points.size(), points, parameters, lcm, puv);
 
-  // Ensure the function returns true since the condition is met for at least one triangle
-  EXPECT_TRUE(decide.Lic10());
-}
-
-// Negative test case for LIC10(),
-// Test case for Decide::Lic10() returning true when all triangles have area within threshold
-// Expected value FALSE
-TEST(CMV, LIC10_NEGATIVE) {
-  // Define input points and parameters
-  std::vector<COORDINATE> points = {
-      {0, 0}, {1, 0}, {0, 1}, {1, 1}, {2, 2}  // Ensure area of all triangles is within threshold
-  };
-  // create parameters container
-  PARAMETERS_T parameters = {
-      10,  // LENGTH1
-      0,   // RADIUS1
-      0,   // EPSILON
-      10,  // AREA1: Set to a value that no triangle formed by the input points will exceed
-      0,   // Q_PTS
-      0,   // QUADS
-      0,   // DIST
-      0,   // N_PTS
-      0,   // K_PTS
-      0,   // A_PTS
-      0,   // B_PTS
-      0,   // C_PTS
-      0,   // D_PTS
-      1,   // E_PTS
-      1,   // F_PTS
-      0,   // G_PTS
-      0,   // LENGTH2
-      0,   // RADIUS2
-      0    // AREA2
-  };
-  // these variables dont matter for this test
-  std::array<std::array<CONNECTORS, 15>, 15> lcm;
-  std::array<bool, 15> puv = {0};
-
-  Decide decide(points.size(), points, parameters, lcm, puv);
-
-  // Ensure the function returns false since the condition is not met for any triangle
+  // Ensure the function returns false since the condition is not met for any
+  // triangle
   EXPECT_FALSE(decide.Lic10());
 }
 
@@ -674,8 +700,8 @@ TEST(CMV, LIC12_POSITIVE) {
   // create parameters container
   PARAMETERS_T parameters;
   parameters.K_PTS = 2;
-  parameters.LENGTH1 = 4.8;  // 0.1 and 5.1 >= 5
-  parameters.LENGTH2 = 1.6;  // 0.1 and 1.0 <= 1.5
+  parameters.LENGTH1 = 4.8; // 0.1 and 5.1 >= 5
+  parameters.LENGTH2 = 1.6; // 0.1 and 1.0 <= 1.5
   // dummy parameters
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
   std::array<bool, 15> puv;
@@ -718,7 +744,7 @@ TEST(CMV, LIC12_NEGATIVE_LENGHT1) {
   // create parameters container
   PARAMETERS_T parameters;
   parameters.K_PTS = 2;
-  parameters.LENGTH1 = 5;  // should be equal and fail
+  parameters.LENGTH1 = 5; // should be equal and fail
   parameters.LENGTH2 = 4;
   // dummy parameters
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
@@ -837,7 +863,8 @@ TEST(CMV, LIC13_BOUNDRARY) {
 // Test whether LIC14 will return true if area is within region
 // Expected value TRUE
 TEST(CMV, LIC14_POSITIVE) {
-  std::vector<COORDINATE> points = {{0,0},{0,4},{3,3},{4,0},{8,0},{5,5}};
+  std::vector<COORDINATE> points = {{0, 0}, {0, 4}, {3, 3},
+                                    {4, 0}, {8, 0}, {5, 5}};
   // area=12,12
   // create parameters container
   PARAMETERS_T parameters;
@@ -857,69 +884,84 @@ TEST(CMV, LIC14_POSITIVE) {
 // Negative test case for LIC14(),
 // Test whether LIC14 will return false if area is beyond region
 // Expected value FALSE
-TEST(CMV, LIC14_NEGATIVE){
-  std::vector<COORDINATE> points = { {0,0},{0,4},{4,4},{4,0},{1,0}};
+TEST(CMV, LIC14_NEGATIVE) {
+  std::vector<COORDINATE> points = {{0, 0}, {0, 4}, {4, 4}, {4, 0}, {1, 0}};
   // area=2
   // create parameters container
   PARAMETERS_T parameters;
   parameters.E_PTS = 1;
   parameters.F_PTS = 1;
-  parameters.AREA1= 6;
-  parameters.AREA2= 16;
+  parameters.AREA1 = 6;
+  parameters.AREA2 = 16;
   // dummy variables
   std::array<std::array<CONNECTORS, 15>, 15> lcm;
   std::array<bool, 15> puv;
 
   Decide decide(points.size(), points, parameters, lcm, puv);
-  //Compare
+  // Compare
   EXPECT_EQ(decide.Lic14(), false);
 }
 
-// Test that launch is true given some inputs that should fulfill lic requirements 0, 3 and 6.
+// Test that launch is true given some inputs that should fulfill lic
+// requirements 0, 3 and 6.
 TEST(LAUNCH, LAUNCH_POSITIVE) {
 
-  std::vector<COORDINATE> points = {{0,0}, {100,100}, {0, 0}, {20, 0}, {0,20}, {0,0}, {50, 0}, {100, 100}};
+  std::vector<COORDINATE> points = {{0, 0},  {100, 100}, {0, 0},  {20, 0},
+                                    {0, 20}, {0, 0},     {50, 0}, {100, 100}};
 
   PARAMETERS_T parameters = {
-      100,  // LENGTH1
-      9.5,  // RADIUS1
-      0,  // EPSILON
-      5,  // AREA1
-      0,  // Q_PTS
-      0,  // QUADS
+      100, // LENGTH1
+      9.5, // RADIUS1
+      0,   // EPSILON
+      5,   // AREA1
+      0,   // Q_PTS
+      0,   // QUADS
       10,  // DIST
-      3,  // N_PTS
-      0,  // K_PTS
-      0,  // A_PTS
-      0,  // B_PTS
-      0,  // C_PTS
-      0,  // D_PTS
-      1,  // E_PTS
-      1,  // F_PTS
-      0,  // G_PTS
-      0,  // LENGTH2
-      0,  // RADIUS2
-      0   // AREA2
+      3,   // N_PTS
+      0,   // K_PTS
+      0,   // A_PTS
+      0,   // B_PTS
+      0,   // C_PTS
+      0,   // D_PTS
+      1,   // E_PTS
+      1,   // F_PTS
+      0,   // G_PTS
+      0,   // LENGTH2
+      0,   // RADIUS2
+      0    // AREA2
   };
 
-  std::array<std::array<CONNECTORS, 15>, 15> lcm = 
-    {{
-      {ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR ,ORR, ORR, ORR, ORR},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR ,ORR, ORR, ORR, ORR},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR ,ORR, ORR, ORR, ORR},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED}
-    }};
+  std::array<std::array<CONNECTORS, 15>, 15> lcm = {
+      {{ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR,
+        ORR},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR,
+        ORR},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR, ORR,
+        ORR},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED}}};
 
   // Lic0, 3 and 6 need to be true.
   std::array<bool, 15> puv = {false};
@@ -937,49 +979,63 @@ TEST(LAUNCH, LAUNCH_POSITIVE) {
 
 // Tests that launch is true if entire LCM is notused
 TEST(LAUNCH, LAUNCH_POSITIVE2) {
-  std::vector<COORDINATE> points = {{0,0}, {100,100}, {0, 0}, {20, 0}, {0,20}, {0,0}, {50, 0}, {100, 100}};
+  std::vector<COORDINATE> points = {{0, 0},  {100, 100}, {0, 0},  {20, 0},
+                                    {0, 20}, {0, 0},     {50, 0}, {100, 100}};
 
   PARAMETERS_T parameters = {
-      100,  // LENGTH1
-      9.5,  // RADIUS1
-      0,  // EPSILON
-      5,  // AREA1
-      0,  // Q_PTS
-      0,  // QUADS
+      100, // LENGTH1
+      9.5, // RADIUS1
+      0,   // EPSILON
+      5,   // AREA1
+      0,   // Q_PTS
+      0,   // QUADS
       10,  // DIST
-      3,  // N_PTS
-      0,  // K_PTS
-      0,  // A_PTS
-      0,  // B_PTS
-      0,  // C_PTS
-      0,  // D_PTS
-      1,  // E_PTS
-      1,  // F_PTS
-      0,  // G_PTS
-      0,  // LENGTH2
-      0,  // RADIUS2
-      0   // AREA2
+      3,   // N_PTS
+      0,   // K_PTS
+      0,   // A_PTS
+      0,   // B_PTS
+      0,   // C_PTS
+      0,   // D_PTS
+      1,   // E_PTS
+      1,   // F_PTS
+      0,   // G_PTS
+      0,   // LENGTH2
+      0,   // RADIUS2
+      0    // AREA2
   };
-  
+
   // A pum of only not used should always give a true launch
-  std::array<std::array<CONNECTORS, 15>, 15> lcm = 
-    {{
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
-      {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED}
-    }};
+  std::array<std::array<CONNECTORS, 15>, 15> lcm = {
+      {{NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED},
+       {NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED,
+        NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED}}};
 
   // Lic0, 3 and 6 need to be true.
   std::array<bool, 15> puv = {true};
@@ -990,39 +1046,53 @@ TEST(LAUNCH, LAUNCH_POSITIVE2) {
   EXPECT_EQ(decide.LAUNCH, true);
 }
 
-// Test case that checks that the function sets launch when it requires all lics 
+// Test case that checks that the function sets launch when it requires all lics
 // to be true at the same time and they are
 TEST(LAUNCH, LAUNCH_POSITIVE3) {
-  
-  std::vector<COORDINATE> points = {{1,2},{3,4}};
+
+  std::vector<COORDINATE> points = {{1, 2}, {3, 4}};
   // This lcm should mean every single LIC specified in PUV needs to be true
-  std::array<std::array<CONNECTORS, 15>, 15> lcm = 
-    {{
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-    }};      
- 
+  std::array<std::array<CONNECTORS, 15>, 15> lcm = {{
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+  }};
+
   std::array<bool, 15> puv = {true};
 
   PARAMETERS_T parameters;
 
   Decide decide(points.size(), points, parameters, lcm, puv);
-  
-  for(int i = 0; i < 15; ++i) {
-    decide.CMV[i]= true;
+
+  for (int i = 0; i < 15; ++i) {
+    decide.CMV[i] = true;
   }
 
   decide.Calc_PUM();
@@ -1035,36 +1105,50 @@ TEST(LAUNCH, LAUNCH_POSITIVE3) {
 // All lics are required to be true for launch to be true, all except one are.
 // verify that launch is false in this instance.
 TEST(LAUNCH, LAUNCH_NEGATIVE2) {
-  
-  std::vector<COORDINATE> points = {{1,2},{3,4}};
+
+  std::vector<COORDINATE> points = {{1, 2}, {3, 4}};
   // This lcm should mean every single LIC specified in PUV needs to be true
-  std::array<std::array<CONNECTORS, 15>, 15> lcm = 
-    {{
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-    }};      
- 
+  std::array<std::array<CONNECTORS, 15>, 15> lcm = {{
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+  }};
+
   std::array<bool, 15> puv = {true};
 
   PARAMETERS_T parameters;
 
   Decide decide(points.size(), points, parameters, lcm, puv);
-  
-  for(int i = 0; i < 15; ++i) {
-    decide.CMV[i]= true;
+
+  for (int i = 0; i < 15; ++i) {
+    decide.CMV[i] = true;
   }
   decide.CMV[0] = false;
 
@@ -1075,53 +1159,69 @@ TEST(LAUNCH, LAUNCH_NEGATIVE2) {
   EXPECT_EQ(decide.LAUNCH, false);
 }
 
-// A really strict test case were every single lic needs to be true for 
+// A really strict test case were every single lic needs to be true for
 // the launch to be true. In this case every single lic isnt true.
 TEST(LAUNCH, LAUNCH_NEGATIVE) {
 
-  std::vector<COORDINATE> points = {{0,0}, {100,100}, {0, 0}, {20, 0}, {0,20}, {0,0}, {50, 0}, {100, 100}};
+  std::vector<COORDINATE> points = {{0, 0},  {100, 100}, {0, 0},  {20, 0},
+                                    {0, 20}, {0, 0},     {50, 0}, {100, 100}};
 
   PARAMETERS_T parameters = {
-      10,  // LENGTH1
-      10,   // RADIUS1
-      10,   // EPSILON
-      10,  // AREA1: Set to a value that no triangle formed by the input points will exceed
-      10,   // Q_PTS
-      10,   // QUADS
-      10,   // DIST
-      10,   // N_PTS
-      10,   // K_PTS
-      10,   // A_PTS
-      10,   // B_PTS
-      10,   // C_PTS
-      10,   // D_PTS
-      1,   // E_PTS
-      1,   // F_PTS
-      3,   // G_PTS
-      3,   // LENGTH2
-      3,   // RADIUS2
-      3    // AREA2
+      10, // LENGTH1
+      10, // RADIUS1
+      10, // EPSILON
+      10, // AREA1: Set to a value that no triangle formed by the input points
+          // will exceed
+      10, // Q_PTS
+      10, // QUADS
+      10, // DIST
+      10, // N_PTS
+      10, // K_PTS
+      10, // A_PTS
+      10, // B_PTS
+      10, // C_PTS
+      10, // D_PTS
+      1,  // E_PTS
+      1,  // F_PTS
+      3,  // G_PTS
+      3,  // LENGTH2
+      3,  // RADIUS2
+      3   // AREA2
   };
-  
+
   // This lcm should mean every single LIC specified in PUV needs to be true
-  std::array<std::array<CONNECTORS, 15>, 15> lcm = 
-    {{
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD},
-    }};      
+  std::array<std::array<CONNECTORS, 15>, 15> lcm = {{
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+      {ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD, ANDD,
+       ANDD, ANDD, ANDD},
+  }};
   // Lic0, 3 and 6 need to be true.
   std::array<bool, 15> puv = {true};
 


### PR DESCRIPTION
Format source files in src/ and test/
using the .clang-format formatting rules.

Code is now formatted according to the specified
rules.

Closes #87